### PR TITLE
Fix malformed penalty markup and add Moodle 5.2 CI coverage

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -1,0 +1,122 @@
+name: Moodle Plugin CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Moodle ${{ matrix.moodle }} / PHP ${{ matrix.php }} / ${{ matrix.database }}
+    runs-on: ubuntu-24.04
+
+    services:
+      postgres:
+        image: ${{ matrix.database == 'pgsql' && 'postgres:17' || '' }}
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+
+      mariadb:
+        image: ${{ matrix.database == 'mariadb' && 'mariadb:11' || '' }}
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: '1'
+          MYSQL_CHARACTER_SET_SERVER: utf8mb4
+          MYSQL_COLLATION_SERVER: utf8mb4_unicode_ci
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - moodle: '4.5'
+            moodle-branch: MOODLE_405_STABLE
+            php: '8.1'
+            database: mariadb
+          - moodle: '5.0'
+            moodle-branch: MOODLE_500_STABLE
+            php: '8.2'
+            database: pgsql
+          - moodle: '5.1'
+            moodle-branch: MOODLE_501_STABLE
+            php: '8.3'
+            database: mariadb
+          - moodle: '5.2'
+            moodle-branch: MOODLE_502_STABLE
+            php: '8.4'
+            database: pgsql
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v6
+        with:
+          path: plugin
+          persist-credentials: false
+
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000, opcache.enable_cli=1
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci '^4.5.10'
+          echo "$(cd ci/bin && pwd)" >> "$GITHUB_PATH"
+          echo "$(cd ci/vendor/bin && pwd)" >> "$GITHUB_PATH"
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> "$GITHUB_ENV"
+
+      - name: Install Moodle and plugin
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: PHP lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phplint
+
+      - name: Validate plugin metadata
+        if: ${{ !cancelled() }}
+        run: |
+          moodle-plugin-ci validate
+          moodle-plugin-ci savepoints
+
+      - name: PHPUnit tests
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpunit --fail-on-warning
+
+      # Keep inherited style debt visible while the functional matrix becomes
+      # the compatibility gate for maintenance releases.
+      - name: Legacy code-quality report
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: |
+          status=0
+          moodle-plugin-ci phpcs --max-warnings 0 || status=$?
+          moodle-plugin-ci phpdoc --max-warnings 0 || status=$?
+          moodle-plugin-ci phpmd || status=$?
+          exit "$status"
+
+      - name: Mark cancelled jobs as failed
+        if: ${{ cancelled() }}
+        run: exit 1

--- a/behaviour.php
+++ b/behaviour.php
@@ -267,7 +267,7 @@ class qbehaviour_regexpadaptivewithhelp extends qbehaviour_adaptive {
         $helppenalty = format_float($penalty, $dp);
         // If total of help penalties >= 1 then display total in red.
         if ($helppenalty >= 1) {
-            $helppenalty = '<span class="flagged-tag">' .$helppenalty . '<span>';
+            $helppenalty = '<span class="flagged-tag">' . $helppenalty . '</span>';
         }
         $output = '';
         $output .= get_string($penaltystring, 'qbehaviour_regexpadaptivewithhelp', $helppenalty).' ';

--- a/tests/behaviour_test.php
+++ b/tests/behaviour_test.php
@@ -1,0 +1,44 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace qbehaviour_regexpadaptivewithhelp;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/question/behaviour/regexpadaptivewithhelp/behaviour.php');
+
+/**
+ * Tests for the RegExp adaptive behaviour with help.
+ *
+ * @package    qbehaviour_regexpadaptivewithhelp
+ * @copyright  2026 RegExp plugin maintainers
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class behaviour_test extends \advanced_testcase {
+    /**
+     * The penalty helper must emit balanced markup when a total is flagged.
+     */
+    public function test_flagged_penalty_has_balanced_markup(): void {
+        $reflection = new \ReflectionClass(\qbehaviour_regexpadaptivewithhelp::class);
+        $behaviour = $reflection->newInstanceWithoutConstructor();
+
+        $output = $behaviour->get_help_penalty(1, 2, 'totalpenalties');
+
+        $this->assertStringContainsString('<span class="flagged-tag">1.00</span>', $output);
+        $this->assertSame(substr_count($output, '<span'), substr_count($output, '</span>'));
+    }
+}


### PR DESCRIPTION
Close the highlighted penalty span correctly, add a regression test for balanced markup, and add a CI matrix for Moodle 4.5 through 5.2.

Locally verified with clean installs on Moodle 5.0.9, 5.1.6+ and 5.2.2+. The behaviour test passed 1 test / 2 assertions on every version, PHP lint passed under PHP 8.2, 8.3 and 8.4, and the new test passes Moodle Coding Style.